### PR TITLE
fix wrong bracketing for negative values in is_inside

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`_.
 `Unreleased`_
 -------------
 
-Nothing yet.
+- fix wrong bracketing for negative values in is_inside (ShoeBox)
 
 `0.4.3`_ - 2021-02-18
 ---------------------

--- a/pyroomacoustics/room.py
+++ b/pyroomacoustics/room.py
@@ -2549,4 +2549,4 @@ class ShoeBox(Room):
         True if ``pos`` is a point in the room, ``False`` otherwise.
         """
         pos = np.array(pos)
-        return np.all(pos) >= 0 and np.all(pos <= self.shoebox_dim)
+        return np.all(pos >= 0) and np.all(pos <= self.shoebox_dim)


### PR DESCRIPTION
Thanks for sending a pull request (PR), we really appreciate that! Before hitting the submit button, we'd be really glad if you could make sure all the following points have been cleared.

Please also refer to the doc on [contributing](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html) for more details. Even if you can't check all the boxes below, do not hesitate to go ahead with the PR and ask for help there.

- [ ] Are there docstrings ? Do they follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) style ?
- [ ] Have you run the tests by doing `nosetests` or `py.test` at the root of the repo ?
- [ ] Have you checked that the doc builds properly and that any new file has been added to the repo ? How to do that is covered in the [documentation](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html#documentation).
- [ ] Is there a unit test for the proposed code modification ? If the PR addresses an issue, the test should make sure the issue is fixed.
- [ ] Last but not least, did you document the proposed change in the CHANGELOG file ? It should go under "Unreleased".

Happy PR :smiley:
